### PR TITLE
enhance: Don't show the empty <div class="py-3"> tag

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,7 @@
+#site-news-forum div[class="py-3"] {
+    display: none;
+}
+
 #region-main #block-site-news .forumpost img.userpicture {
     width: auto; /* override */
     height: auto; /* override */


### PR DESCRIPTION
Beim Rendern von 
`get_detailed_discussion_list_renderer($forum, 'mod_forum/frontpage_social_discussion_list')`
Wird auch das Template [/mod/forum/templates/discussion_list.mustache](https://github.com/moodle/moodle/blob/main/mod/forum/templates/discussion_list.mustache#L53) integriert.

Dort wird ein leeres <div class="py-3> erzeugt, weil keine der Optionen darin durch die Templatedaten getriggert werden. Dies verursacht letztlich einen unschönen Abstand auf der Website .

Hiermit wird der[ leere `<div class="py-3">` tag](https://github.com/moodle/moodle/blob/77a7d81290f11aefb258a0967d3dcf2d3d26dbb3/mod/forum/templates/discussion_list.mustache#L53) entfernt.

(`#site-news-forum div[class="py-3"]:empty {...}` funktioniert nicht weil das div Whitespace-Zeichen enthält)
Fixes #8 